### PR TITLE
Fixing minor issues

### DIFF
--- a/kubernetes/production/deployment.yaml
+++ b/kubernetes/production/deployment.yaml
@@ -39,6 +39,11 @@ spec:
         args:
         - tmpld /templates/*.j2
         env:
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
         - name: ERLANG_HOSTNAME
           valueFrom:
             configMapKeyRef:

--- a/kubernetes/production/deployment.yaml
+++ b/kubernetes/production/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         image: telephoneorg/tmpld
         imagePullPolicy: IfNotPresent
         args:
-        - tmpld /templates/**/*.j2
+        - tmpld /templates/*.j2
         env:
         - name: ERLANG_HOSTNAME
           valueFrom:

--- a/kubernetes/production/templates.yaml
+++ b/kubernetes/production/templates.yaml
@@ -7,7 +7,7 @@ metadata:
     project: telephoneorg
     environment: production
 data:
-  sys.config: |
+  sys.config.j2: |
     ---
     target: /config/sys.config
     ---

--- a/kubernetes/testing/local.yaml
+++ b/kubernetes/testing/local.yaml
@@ -214,6 +214,11 @@ spec:
         args:
         - tmpld /templates/*.j2
         env:
+        - name: KUBE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
         - name: ERLANG_HOSTNAME
           valueFrom:
             configMapKeyRef:

--- a/kubernetes/testing/local.yaml
+++ b/kubernetes/testing/local.yaml
@@ -38,7 +38,7 @@ metadata:
     project: telephoneorg
     environment: production
 data:
-  sys.config: |
+  sys.config.j2: |
     ---
     target: /config/sys.config
     ---
@@ -212,7 +212,7 @@ spec:
         image: telephoneorg/tmpld
         imagePullPolicy: IfNotPresent
         args:
-        - tmpld /templates/**/*.j2
+        - tmpld /templates/*.j2
         env:
         - name: ERLANG_HOSTNAME
           valueFrom:


### PR DESCRIPTION
I think it would be better to have KUBE_NAMESPACE variable around, because somebody(like me) may use this setup in a different namespace. In that case, this variable is necessary.